### PR TITLE
bump iban-commons 1.8.3 → 1.8.7

### DIFF
--- a/imixs-adapters-sepa/pom.xml
+++ b/imixs-adapters-sepa/pom.xml
@@ -30,12 +30,11 @@
 			<artifactId>imixs-marty</artifactId>
 		</dependency>
 
-
-		<!-- tiny java lib for iban/bic validation -->
+		<!-- java lib for iban/bic validation -->
 		<dependency>
 			<groupId>de.speedbanking</groupId>
 			<artifactId>iban-commons</artifactId>
-			<version>1.8.4</version>
+			<version>1.8.7</version>
 		</dependency>
 
 	</dependencies>

--- a/imixs-adapters-sepa/src/main/java/org/imixs/workflow/sepa/plugins/IBANBICPlugin.java
+++ b/imixs-adapters-sepa/src/main/java/org/imixs/workflow/sepa/plugins/IBANBICPlugin.java
@@ -139,7 +139,7 @@ public class IBANBICPlugin extends AbstractPlugin {
      *
      * @throws InvalidIbanException if any IBAN value is invalid
      */
-    public void validateIBAN(ItemCollection workitem, String... itemNames) {
+    public void validateIBAN(ItemCollection workitem, String... itemNames) throws InvalidIbanException {
         for (String itemName : itemNames) {
             String iban = workitem.getItemValueString(itemName);
             if (iban.isEmpty()) {
@@ -152,7 +152,7 @@ public class IBANBICPlugin extends AbstractPlugin {
                 // Remove all whitespace before validation
                 iban = iban.replaceAll("\\s+", "");
             }
-            Iban.of(iban);
+            Iban.validate(iban);
         }
     }
 
@@ -163,7 +163,7 @@ public class IBANBICPlugin extends AbstractPlugin {
      *
      * @throws InvalidBicException if any BIC value is invalid
      */
-    public void validateBIC(ItemCollection workitem, String... itemNames) {
+    public void validateBIC(ItemCollection workitem, String... itemNames) throws InvalidBicException {
         for (String itemName : itemNames) {
             String bic = workitem.getItemValueString(itemName);
             if (bic.isEmpty()) {
@@ -172,7 +172,7 @@ public class IBANBICPlugin extends AbstractPlugin {
             if (!sepaValidationStrict) {
                 bic = bic.replaceAll("\\s+", "");
             }
-            Bic.of(bic);
+            Bic.validate(bic);
         }
     }
 


### PR DESCRIPTION
Bumps `iban-commons` from 1.8.3 to 1.8.7 and switches both JSF validators to the new allocation-free API.
`Iban.validate()` and `Bic.validate()` carry the same exception contract as `of()` - invalid input throws `InvalidIbanException`/`InvalidBicException` with full error detail - but skip constructing the domain object, which is unnecessary in a validation-only context.